### PR TITLE
Fixed the subscription handler to not need id prefixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,14 +96,14 @@ This function is run each update, and can and should react to the new state to t
 ```javascript
 subscribe: (state) => {
   return [
-    ['unique-identifier', subscriptionMethod, param1, param2, param3, ...],
-    ['another-subscription-identifier', subMethod, param1, param2, param3, ...],
+    [subscriptionMethod, param1, param2, param3, ...],
+    [subMethod, param1, param2, param3, ...],
     ...
   ]
 }
 ```
 
-Each subscription needs at least a unique identifier and a subscription method.
+Each subscription needs at least a subscription method.
 
 Subscription methods should look like the following:
 

--- a/examples/cli/timer-with-subscription.js
+++ b/examples/cli/timer-with-subscription.js
@@ -19,7 +19,7 @@ ferp.app({
   },
 
   subscribe: state => [
-    state < 5 && ['ticker', every.second, 1, 'INCREMENT'],
+    state < 5 && [every.second, 1, 'INCREMENT'],
   ],
 
   middleware: [logger(), immutable()],

--- a/examples/game-input/main.js
+++ b/examples/game-input/main.js
@@ -84,7 +84,7 @@ const createApp = () => ferp.app({
   },
 
   subscribe: () => [
-    ['keyhandler', keyboardSubscription, 'KEY_DOWN', 'KEY_UP'],
+    [keyboardSubscription, 'KEY_DOWN', 'KEY_UP'],
   ],
 });
 

--- a/examples/http-server/server.js
+++ b/examples/http-server/server.js
@@ -21,9 +21,8 @@ ferp.app({
   }),
 
   subscribe: () => [
-    ['server', serverSubscription, 8080, 'ROUTE'],
+    [serverSubscription, 8080, 'ROUTE'],
   ],
 
   middleware: [ferp.middleware.logger(2), ferp.middleware.immutable()],
 });
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ferp",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "module": "src/ferp.js",
   "main": "dist/ferp.js",
   "description": "Build functional and pure applications in NodeJS and the Browser!",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "directories": {
     "example": "examples"
   },

--- a/src/app.test.js
+++ b/src/app.test.js
@@ -65,7 +65,7 @@ test.cb('app can enable a subscription which can dispatch an update', (t) => {
       }
     },
     subscribe: state => [
-      state && ['test', emptySub],
+      state && [emptySub],
     ],
   });
 });

--- a/src/subscribeHandler.js
+++ b/src/subscribeHandler.js
@@ -1,0 +1,36 @@
+const compareValue = (a, b) => {
+  if (typeof a !== typeof b) return false;
+  if (typeof a !== 'object') return a === b;
+  if (a === null && b === null) return true;
+  return Object.keys(a).every(key => compareValue(a[key], b[key]));
+};
+
+const subscriptionComparator = args => (subArgs) => {
+  if (args.length !== subArgs.length) return false;
+  return args.every((value, position) => compareValue(value, subArgs[position]));
+};
+
+const initSub = (args, dispatch) => {
+  const [method, ...trailing] = args;
+  return method(...trailing)(dispatch);
+};
+
+const toSubscription = (args, dispatch) => ({
+  isSub: subscriptionComparator(args),
+  detach: initSub(args, dispatch),
+  raw: args,
+});
+
+export const subscribeHandler = (prevSubs, subscriptions, dispatch) => {
+  const initialSubs = prevSubs.filter((prevSub) => {
+    const keepSub = subscriptions.some(sub => prevSub.isSub(sub));
+    if (!keepSub) prevSub.detach();
+    return keepSub;
+  });
+
+  const newSubs = subscriptions.filter(Boolean).filter(nextSub => (
+    !prevSubs.some(sub => sub.isSub(nextSub))
+  ));
+
+  return initialSubs.concat(newSubs.map(sub => toSubscription(sub, dispatch)));
+};

--- a/src/subscriptions/README.md
+++ b/src/subscriptions/README.md
@@ -11,7 +11,7 @@ A subscription using every may look something like:
 app({
   // ...
   subscribe: () => [
-    ['unique-id', ferp.subscriptions.Every.minute, 1, 'SOME_ACTION'],
+    [ferp.subscriptions.Every.minute, 1, 'SOME_ACTION'],
   ],
 })
 ```
@@ -36,7 +36,7 @@ And it would be called like this:
 app({
   // ...
   subscribe: () => [
-    ['unique-id', mySub],
+    [mySub],
   ],
 })
 ```
@@ -59,7 +59,7 @@ Now we can pass our message to the subscription:
 app({
   // ...
   subscribe: () => [
-    ['unique-id', mySub, { my: 'message' }],
+    [mySub, { my: 'message' }],
   ],
 })
 ```


### PR DESCRIPTION
## What

 - Removes the id from a subscription tuple.
 - Bumps minor version, because it's a breaking pre-1.0 release.

## Tasks

 - [x] Imports subscribeHandler.js from my other branch.
 - [x] Update all documentation and examples to remove unique ids from subscribe output.
 - [x] Increase minor version

## GIF

![](https://media.giphy.com/media/9PyhoXey73EpW/giphy.gif)